### PR TITLE
[UX] Reduce whitespace when printing content & add button for printing college guide

### DIFF
--- a/content/college-guide/_index.md
+++ b/content/college-guide/_index.md
@@ -5,3 +5,5 @@ weight: 1
 
 A chronological summary of the college application process, with links
 to more detailed pages.
+
+<button onClick="printCollegeGuide();">Print College Guide</button>

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,2 +1,4 @@
 <!-- https://gohugo.io/getting-started/configuration-markup#heading-link-example -->
-<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }} <a href="#{{ .Anchor | safeURL }}"> ¶</a></h{{ .Level }}>
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }}
+    <a href="#{{ .Anchor | safeURL }}"><span class="not-for-print"> ¶</span></a>
+</h{{ .Level }}>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,3 +1,9 @@
+{{ define "extend_head" }}
+{{ if eq (urls.Parse .Permalink).Path "/college-guide/" }}
+<script type="text/javascript" src="/js/PrintCollegeGuide.js"></script>
+{{ end }}
+{{ end }}
+
 {{ define "main" }}
 <main>
     <article>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -15,7 +15,7 @@ body {
     font-family: 'Open Sans', sans-serif;
     font-weight: 100;
     background-color: #f6f6f6;
-    line-height: 200%;      
+    line-height: 200%;
 }
 
 #site-navbar, #site-footer, #main_div {
@@ -29,7 +29,7 @@ body {
     padding: 2% 5% 2% 5%;
 }
 
-/* If the browser window reduces in size, remove the padding 
+/* If the browser window reduces in size, remove the padding
  * from the main content */
  @media screen and (max-width: 900px) {
     #main_div {
@@ -97,11 +97,11 @@ nav ul li {
 .breadcrumb ul {
     display: flex;
 }
-    
+
 .breadcrumb li::before {
     content: " ⇒ ";
 }
-    
+
 .breadcrumb li:first-child::before {
     content: "";
 }
@@ -118,7 +118,7 @@ nav#TableOfContents li {
     font-size: 1.2em;
 }
 
-ul.posts { 
+ul.posts {
     margin: 20px auto 40px;
 }
 
@@ -154,7 +154,7 @@ tr:nth-child(even){
 
 td.no-decoration {
     border: none;
-} 
+}
 
 tr.no-decoration {
     background-color: inherit;
@@ -170,8 +170,8 @@ tr.no-decoration {
 }
 
 div.comment-holder > div.comment {
-    text-align: left; 
-    color: #4CAF50; 
+    text-align: left;
+    color: #4CAF50;
     border-left: rgb(24, 179, 179) solid thick;
     padding: 1% 2%;
     max-width: 75%;
@@ -212,4 +212,19 @@ span#draft-marker {
     padding: 1px 10px;
     border: red thin solid;
     border-radius: 3px;
+}
+
+@media print {
+    .not-for-print {
+        display: none;
+    }
+
+    body {
+        margin: 0;
+        line-height: 140%;
+    }
+
+    #site-navbar, #site-footer, #main_div {
+        margin: 0;
+    }
 }

--- a/static/js/PrintCollegeGuide.js
+++ b/static/js/PrintCollegeGuide.js
@@ -1,0 +1,66 @@
+/**
+ * Fetch the URLs of all the pages in the /college-guide/ directory.
+ */
+const getCollegeGuideURLs = new Promise((resolve, _) => {
+    const xhr = new XMLHttpRequest();
+    xhr.onload = function() {
+        let urls = [];
+        for (let item of xhr.responseXML.getElementsByTagName("item")) {
+            urls.push(item.getElementsByTagName("link")[0].innerHTML);
+        }
+        urls.sort();
+        resolve(urls);
+    }
+
+    xhr.open("GET", "/college-guide/index.xml");
+    xhr.responseType = "document";
+    xhr.send();
+});
+
+/**
+ * Adapted from https://developer.mozilla.org/en-US/docs/Web/Guide/Printing
+ */
+function closePrint () {
+    document.body.removeChild(this.__container__);
+}
+
+/**
+ * Adapted from https://developer.mozilla.org/en-US/docs/Web/Guide/Printing
+ */
+function setPrint () {
+    this.contentWindow.__container__ = this;
+    this.contentWindow.onafterprint = closePrint;
+    this.contentWindow.focus(); // Required for IE
+    let doc = this.contentWindow.document;
+
+    // For some reason, the onload event for iframes is called twice. The second
+    // time around has all of the contents loaded.
+    if (doc.children[0].innerText.length > 0) {
+        this.contentWindow.print();
+    }
+}
+
+/**
+ * Adapted from https://developer.mozilla.org/en-US/docs/Web/Guide/Printing
+ */
+function printPage(url) {
+    var oHideFrame = document.createElement("iframe");
+    oHideFrame.onload = setPrint;
+    oHideFrame.style.position = "fixed";
+    oHideFrame.style.right = "0";
+    oHideFrame.style.bottom = "0";
+    oHideFrame.style.width = "0";
+    oHideFrame.style.height = "0";
+    oHideFrame.style.border = "0";
+    oHideFrame.src = url;
+    document.body.appendChild(oHideFrame);
+}
+
+/** Print all of the pages in the college guide. */
+function printCollegeGuide() {
+    getCollegeGuideURLs.then((urls) => {
+        for (let url of urls) {
+            printPage(url);
+        }
+    });
+}


### PR DESCRIPTION
<figure>
<img width="400" alt="Print preview that has more whitespace and header characters" src="https://user-images.githubusercontent.com/13133947/154589768-9154fdf3-5c99-4b40-9960-63d375a74f29.png">
<figcaption>[Before] Notice the spacing within the document to be printed.</figcaption>
</figure>
<br />
<br />

<figure>
<img width="400" alt="Print preview that has tighter text packing and header characters" src="https://user-images.githubusercontent.com/13133947/154589668-e29cf2bd-963d-4ddd-9b87-3376fb012ad3.png">
<figcaption>[Proposed] Notice that the text is more compact, and headers lack the ¶ character.</figcaption>
</figure>

<br /><br />
This PR also adds a "Print College Guide" button to the /college-guide/ page [1]:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/13133947/154590265-2fc4cef5-cc32-44df-bce8-5db6f16b59c8.png">

When clicked, the print dialog will be invoked on each page in /college-guide/*.

[1]: https://deploy-preview-16--kenyansapplyingtousuniversities.netlify.app/college-guide/