### PR TITLE
[SATs] Discontinuation of the SAT Essay and Subject Tests

### DIFF
--- a/content/blog-posts/2018-08-06-to-kenyan-parents-an-argument-for-sending-your-child-to-a-us-college.md
+++ b/content/blog-posts/2018-08-06-to-kenyan-parents-an-argument-for-sending-your-child-to-a-us-college.md
@@ -21,11 +21,9 @@ This post is directed to Kenyan parents/guardians who have child in high
 school that is about to sit for their KCSE. It’s never too early to
 start thinking of possible next steps.
 
-If your child has already ~~graduated from high school but has not
-started applying to schools in the US~~ started undergraduate classes at
-a local university, it’s a bit risky for them to start thinking of
-undergraduate US universities. The applications and required exams are
-time-consuming.
+If your child has already started undergraduate classes at a local
+university, it’s a bit risky for them to start thinking of undergraduate
+US universities. The applications and required exams are time-consuming.
 
 When I talk about US universities, I’m only referring to the ones that
 provide full (or close to full) scholarships to international students
@@ -98,9 +96,10 @@ probably the better choice. Medicine and Law are not offered as
 undergraduate degrees in the US.
 
 The applications open on August 1st, and close by January. The first set
-of admission results are out in December 2018, and the second set of
-results come are released in March/April 2019. If your child gets
-accepted, they’ll start school in the US in September 2019.
+of admission results are out in December, and the second set of
+results come are released in March/April. If your child gets
+accepted, they’ll start school in the US in the September after getting
+their admission results.
 
 A well-crafted college application takes time and effort. Some students
 choose to attend the first year of class at Kenyan universities. Others

--- a/content/blog-posts/2018-08-06-to-kenyan-parents-an-argument-for-sending-your-child-to-a-us-college.md
+++ b/content/blog-posts/2018-08-06-to-kenyan-parents-an-argument-for-sending-your-child-to-a-us-college.md
@@ -37,17 +37,16 @@ not well-versed to advise on such scholarships.
 
 | Item | Cost (USD) | Cost (KES) | Remarks |
 | --- | --- | --- | ---|
-| [SAT I](https://collegereadiness.collegeboard.org/sat/register/international/fees) | 89 or 106 | 8,939 to 10,646 | SATs are the equivalent of KCSE. The SAT I tests on Reading, Writing and Math. 89 USD is for Reading and Math only. Some schools don't need the Writing portion. |
-| [SAT Subject Tests](https://collegereadiness.collegeboard.org/sat-subject-tests/register/international-registration/fees) | 111 or 133 | 11,148 or 13,358 | Subjects include Math, Physics, Chemistry, Biology, etc. 111 USD is for 2 subjects, 133 USD is for 3 subjects. |
-| Application Fee | Between 50 and 100 per university. | 5,022 to 10,043 per university | If you these costs are too much, you can request a waiver. Universities usually grant this waiver. |
-| Miscellaneous | ~75 | 7,533 | SAT Prep Books, Internet Access |
-| Total | Between 275 and 314 | Between 27,619 and 31,536 | We’ve not included the application fees because most applicants request waivers. We recommend applying to 8 schools. |
+| [SAT](https://collegereadiness.collegeboard.org/sat/register/international/fees) | 103 | 12,706 | SATs are the equivalent of KCSE. The SAT tests on Reading and Math. |
+| Application Fee | Between 50 and 100 per university. | 6,168 to 12,335 per university | If you these costs are too much, you can request a waiver. Universities usually grant this waiver. |
+| Miscellaneous | ~75 | 9,252 | SAT Prep Books, Internet Access |
+| Total | 178 | 21,958 | We’ve not included the application fees because most applicants request waivers. We recommend applying to 8 schools. |
 
 {{% comment %}}
 
-The costs in this post were obtained on 6th August, 2018. Conversion
-rate at the time: 1 USD = 100.43 KES. As with most valuable things in
-life, the costs have most likely risen since then.
+The costs in this post were obtained on 26th Dec, 2022. [Conversion
+rate](https://g.co/finance/USD-KES?window=5Y) at the time: 1 USD =
+123.35 KES.
 
 {{% /comment %}}
 

--- a/content/college-guide/07-tests-that-you-need-to-take.md
+++ b/content/college-guide/07-tests-that-you-need-to-take.md
@@ -40,59 +40,23 @@ school in September 2022.
   requires a lot of timing and tact. Practice hard and be smart about
   it!
 
-* Take the SAT + Essay version so as to keep your options as open as
-  possible.
-
-## SAT Subject Tests
-
-* The SAT Subject Tests are 20 multiple choice standardized tests given
-  by College Board on a variety of subjects ranging from Chemistry to
-  languages such as Chinese and Modern Hebrew. Some colleges require a
-  certain number of Subject Tests, others make them optional, while
-  others do not require but we recommend that you take Subject Tests. If
-  you don’t, you’ll severely limit the number of schools you can apply
-  to. The perfect score in any single subject test is 800.
-
-* The classes you take in high school mainly have an influence on what
-  Subject Tests you end up taking, but this doesn’t mean you cannot
-  tackle a subject test that you did not study in high school. Math/
-  Biology/ Physics/ Chemistry are common picks for Subject Tests by
-  Kenyan students as most of us have done this in high school. The
-  Subject Tests require both a good grasp of the material and a good
-  amount of timing and tact. Therefore, practice is key for good results
-  in the Subject Tests.
-
-  * Math comes in two forms, Math IC (Level 1) and Math lIC (Level 2).
-    Don’t let the ‘Level 2’ scare you. While you’ll need to learn new
-    material, Math Level 2 is graded more generously than Math Level 1.
-    Most engineering programs favor Math Level 2 to Math Level 1.
-
-  * Biology E/M also comes in two forms, Ecological and Molecular.
-    Biology E/M with an Ecological focus deals with ecosystems. Biology
-    E/M with a Molecular focus deals with the in cell processes of life.
-    You’ll do the same 60 questions, but then choose the concentration
-    from which your final 20 questions will come from. Practising way
-    before hand allows you to conclusively decide what tests you have a
-    chance to score best on.
-
-  * The SAT Physics Subject Test and the SAT Chemistry Subject Test
-    don’t have any subdivisions that need to be addressed.
-
-* The most useful combination is one Math test, and either Physics or
-  Chemistry. This will fulfill the SAT Subject Test requirement for most
-  schools, including Schools of Engineering (unless the school requires
-  Math Level 2 in which case Math Level 1 won’t do). Very few schools
-  require 3 SAT Subject Tests. Confirm with the university’s website.
+* The [optional SAT Essay and SAT Subject Tests were
+  discontinued](https://blog.collegeboard.org/January-2021-sat-subject-test-and-essay-faq)
+  in Jan 2021 for US students, and in June 2021, for international
+  students. In their place, schools use alternative signals. For
+  example, to evaluate a student's writing skills, schools (e.g.,
+  [Princeton](https://admission.princeton.edu/apply/graded-written-paper))
+  may ask the student to submit a paper that was graded by their
+  teacher.
 
 ## College Board
 
-* [College Board](https://www.collegeboard.org/) administers the SAT and
-  SAT Subject Tests.You need an email account (for convenience, use
-  Gmail) to sign up for College Board. Once you sign up for College
-  Board, you get access to a few SAT online tests and university
-  profiles. You also send your SAT and SAT subject test scores to
-  colleges via College Board, meaning a College Board account is
-  compulsory for applying to study in the US.
+* [College Board](https://www.collegeboard.org/) administers the SAT.
+  You need an email account (for convenience, use Gmail) to sign up for
+  College Board. Once you sign up for College Board, you get access to a
+  few SAT online tests and university profiles. You also send your SAT
+  scores to colleges via College Board, meaning a College Board account
+  is compulsory for applying to study in the US.
 
 * College Board also offers Advanced Placement tests (APs) which are an
   easy way to get out of most requirements in college. APs are not
@@ -120,12 +84,6 @@ school in September 2022.
   them:
   [http://www.princetonreview.com/college/sat-act](http://www.princetonreview.com/college/sat-act)
 
-* While some universities consider the ACT in place of both the SAT and
-  the SAT Subject Tests, some universities will require 2 Subject Tests,
-  in addition to the ACT/SAT. So spare yourself the headache of
-  compiling a list of who needs what and just take the SAT Subject
-  Tests, whether you take the SAT or the ACT.
-
 * Also, when trying to decide between the ACT and SAT, make up your mind
   early enough! Don’t switch your preference at the last minute since
   you won’t have enough time to prepare.
@@ -138,8 +96,8 @@ Nairobi Email: info@lts-africa.com Phone: +254 20-233-0843, +254
 
 * As of August 2016, LTS – East Africa is the only authorized body to
   register students for the SAT and TOEFL – avoid middlemen! The SAT is
-  usually offered in the first week of January, May, June, October,
-  November and December.
+  usually offered in the March, May, June, August, October, and
+  December.
 
 * Registration deadlines for international students applying through an
   International Representative (LTS is Kenya’s International
@@ -149,17 +107,13 @@ Nairobi Email: info@lts-africa.com Phone: +254 20-233-0843, +254
   your College Board account so ensure your identifying details are the
   same).
 
-* The costs for 2018 are:
+* The costs, as of Dec 2022, are:
 
   * [SAT](https://collegereadiness.collegeboard.org/sat/register/international/fees)
-    – $84 without essay, $98 with essay
-
-  * [SAT Subject
-    Tests](https://collegereadiness.collegeboard.org/sat-subject-tests/register/international-registration/fees)
-    – $106 for 2 Subject Tests, $127 for 3 Subject Tests
+    – $103
 
   * [TOEFL-iBT](https://www.ets.org/bin/getprogram.cgi?urlSource=toefl&newRegURL=&test=TOEFL&greClosed=new&greClosedCountry=China&browserType=&toeflType=&redirect=&t_country1=group_Kenya)
-    – $190
+    – $225
 
 ## ProTips
 
@@ -168,12 +122,9 @@ Nairobi Email: info@lts-africa.com Phone: +254 20-233-0843, +254
   format and content is different. Give yourself time to prep for the
   SATs.
 
-* You may do the May & June SATs and if necessary retake in October or
-  November. December is a bit too late and by then, you should be
+* You may do the May & June SATs and if necessary retake in August or
+  October. December is a bit too late and by then, you should be
   focused on application essays.
-
-* *You can’t take both the Redesigned SAT and the SAT Subject Tests on
-  the same day.*
 
 ## TOEFL-iBT
 

--- a/content/college-guide/07-tests-that-you-need-to-take.md
+++ b/content/college-guide/07-tests-that-you-need-to-take.md
@@ -8,10 +8,10 @@ aliases:
 
 {{% comment %}}
 
-The COVID-19 pandemic made it nearly impossible to take the standardized
-tests. As a result, some schools have (temporarily) waived standardized
-testing requirements. To get the latest information, look up the
-school's admissions website.
+The COVID-19 pandemic made it hard to take the standardized tests. As a
+result, some schools have (temporarily) waived standardized testing
+requirements. To get the latest information, look up the school's
+admissions website.
 
 For example, searching the web for "princeton undergraduate admissions
 requirements" leads me to
@@ -133,7 +133,7 @@ Nairobi Email: info@lts-africa.com Phone: +254 20-233-0843, +254
 
 * Mainly required by Canadian universities. Most American universities
   waive this requirement by virtue of Kenya being an English speaking
-  country. Also, English is the language of instruction in Kenyan
+  country, and English being the language of instruction in Kenyan
   schools.
 
 * In case a school insists that you take the TOEFL, register at LTS –

--- a/content/college-guide/08-test-preparation-resources.md
+++ b/content/college-guide/08-test-preparation-resources.md
@@ -112,27 +112,6 @@ non-official material first, and then do the Official ACT Tests as you
 near the test date. Make sure you have enough time to do and review all
 the Official Tests.
 
-### SAT Subject Tests
-
-Unlike the ACT and Redesigned SAT, there aren’t many Official Practice
-Test PDFs floating around. You’ll have to make do with unofficial test
-prep. As you guessed, [CrackSAT](http://www.cracksat.net/sat2/) has free
-practice questions and some prep books as well. Kindly note that some of
-the concepts covered on the SAT Subject Tests were not taught in high
-school. Furthermore, with the exception of Math IC and Math IIC, you’re
-not allowed to use a calculator on the SAT Subject Tests – so this is
-quite different from high school Biology, Physics, and Chemistry.
-
-The general strategy is this: Review the content, then do LOTS of
-practice tests. Here is some [advice from some gurus at College
-Confidential](http://talk.collegeconfidential.com/sat-subject-tests-preparation/1077242-list-of-the-best-sat-subject-test-prep-books.html).
-
-Note: While the gurus endorse a certain book, it doesn’t imply that the
-book was responsible for stellar scores. Their scores may also have had
-to do with their high school curriculum. As a KCPE candidate would say,
-“Don’t put all your eggs in one basket.” Do practice tests from as many
-books as you can.
-
 ### TOEFL-iBT
 
 Since Kenyan high schools are taught in English, students don’t usually

--- a/content/college-guide/11-college-access-programs.md
+++ b/content/college-guide/11-college-access-programs.md
@@ -35,10 +35,9 @@ The program consists of 3 parts. From July to August, students get
 guidance on the SAT & TOEFL, and take the TOEFL Test in August. In the
 2nd part of the program, which begins sometime in September, students
 mainly focus on the SAT Reasoning Test, which they take in October.
-Students also begin intense prep for the SAT Subject Tests and complete
-their first college application to their most desired school. The
-students get a short break and come back for the final stretch in which
-they do their Subject Tests and work on more college applications.
+Students also complete their first college application to their most
+desired school. The students get a short break and come back for the
+final stretch in which they work on more college applications.
 
 It’s worth noting that the [East African Scholars
 Fund](http://www.eastafricanscholarsfund.org/) sponsors EaSEP, so the
@@ -104,10 +103,10 @@ train a bit to ensure that your body is ready for the run. KenSAP picks
 14 – 16 students.
 
 KenSAP students attend camp from July to November, but there are breaks
-in between. In the camp, you’ll get guidance on the TOEFL, SAT, SAT
-Subject Tests and your college applications. Of the college access
-programs that require applications, KenSAP is very selective. It’s worth
-noting that students pay nothing. Kenya Fluorspar sponsors KenSAP.
+in between. In the camp, you’ll get guidance on the standardized tests,
+and your college applications. Of the college access programs that
+require applications, KenSAP is very selective. It’s worth noting that
+students pay nothing. Kenya Fluorspar sponsors KenSAP.
 
 ## EducationUSA
 


### PR DESCRIPTION
The tests were discontinued in June 2021 for international students.

This PR also makes some drive-by fixes in the affected files.

[1]: https://blog.collegeboard.org/January-2021-sat-subject-test-and-essay-faq