### PR TITLE
[Link Hygiene] Fix broken EaSEP links

### DIFF
--- a/content/college-guide/09-examples-of-us-universities-that-kenyans-have-attended-on-scholarships.md
+++ b/content/college-guide/09-examples-of-us-universities-that-kenyans-have-attended-on-scholarships.md
@@ -89,6 +89,6 @@ strategic – have some schools in which you’re likely to get in, and
 others where you require the cosmos to realign in your favor.
 
 * This list has been compiled from [KenSAP](http://kensap.org/) and
-  [EaSEP](http://www.easep.org/) since they have the universities on
+  [EaSEP](http://www.easepkenya.org/) since they have the universities on
   their websites. We don’t have data from other organizations &
   independent applicants. It is not an exhaustive list!

--- a/content/college-guide/11-college-access-programs.md
+++ b/content/college-guide/11-college-access-programs.md
@@ -36,7 +36,7 @@ after a couple of weeks.
 Unless otherwise specified, the programs only accept applications from
 students who completed the most recent KCSE.
 
-## [EaSEP (Education and Social Empowerment Program)](http://www.easep.org/)
+## [EaSEP (Education and Social Empowerment Program)](http://www.easepkenya.org/)
 
 The students stay at a camp in Nandi Hills for weeks at a time. The
 program also pays for its students' [standardized tests]({{< ref
@@ -51,7 +51,7 @@ Requirements:
 * Preferably from (or schooled in) western Kenya.
 
 Application Instructions:
-[https://www.easep.org/apply.html](https://www.easep.org/apply.html)
+[https://www.easepkenya.org/apply.html](https://www.easepkenya.org/apply.html)
 
 ## EALP (Equity African Leaders Program)
 


### PR DESCRIPTION
http://www.easep.org/ no longer belongs to the college prep program. It's now https://www.easepkenya.org/