### PR TITLE
Revert "[ES] Add google-site-verification meta tag (#36)"

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,6 @@
             {{ end }}
         </title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="google-site-verification" content="yhUucdJziOvPpSvj0LwmoTDPx3mCsG2XORxmG5KwSAg" />
         <link rel="stylesheet" type="text/css" href="/css/main.css" />
         <link rel="stylesheet" type="text/css" href="/css/all_font_awesome_v5.9.min.css" />
         <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">


### PR DESCRIPTION
We added domain verification instead. No need for the <meta> tag.